### PR TITLE
Update indexing type for Eigen 3.4 compatibility

### DIFF
--- a/src/biscale.cpp
+++ b/src/biscale.cpp
@@ -23,7 +23,7 @@ Eigen::MatrixXd vec2mat(Eigen::VectorXd x, int type, int num){
 }
 
 // [[Rcpp::export]]
-List biscale_alt(Eigen::MatrixXd x, Eigen::MatrixXd ind, Eigen::VectorXd obsrow, Eigen::VectorXd obscol, int max_it, double tol, Eigen::VectorXd alpha, Eigen::VectorXd beta, Eigen::VectorXd tau, Eigen::VectorXd gamma,
+List biscale_alt(Eigen::MatrixXd x, Eigen::MatrixXi ind, Eigen::VectorXd obsrow, Eigen::VectorXd obscol, int max_it, double tol, Eigen::VectorXd alpha, Eigen::VectorXd beta, Eigen::VectorXd tau, Eigen::VectorXd gamma,
             bool row_mean, bool col_mean, bool row_std, bool col_std) {
   int m = x.rows();
   int n = x.cols();


### PR DESCRIPTION
This PR updates your package's C++ to use an integer matrix (`Eigen::MatrixXi`) instead of a doubles matrix (`Eigen::MatrixXd`) for storing indexing values, otherwise your package will break with the next `RcppEigen` release.

Let me know if you have any questions, thanks!